### PR TITLE
Fix incremental feed date parsing

### DIFF
--- a/src/fetch_incremental.py
+++ b/src/fetch_incremental.py
@@ -61,8 +61,13 @@ def fetch_incremental(days: int = 1):
     records = []
     with gzip.open(gz, "rb") as f:
         for item in ijson.items(f, "CVE_Items.item"):
-            pub_date = item.get("publishedDate","")
-            if pub_date >= since.isoformat():
+            pub_date_raw = item.get("publishedDate", "")
+            try:
+                pub_dt = datetime.fromisoformat(pub_date_raw.replace("Z", "+00:00")) if pub_date_raw else None
+            except ValueError:
+                pub_dt = None
+
+            if pub_dt and pub_dt >= since:
                 cve_id, pub, desc, products, oss = parse_item(item)
                 text_for_emb = f"{desc} {products or ''} {oss or ''}"
                 emb = get_embedding(text_for_emb)


### PR DESCRIPTION
## Summary
- handle `publishedDate` as datetime for incremental fallback

## Testing
- `python3 -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4a7b088c832aabb2c471e49cfb34